### PR TITLE
add network interface selector

### DIFF
--- a/httpdump.py
+++ b/httpdump.py
@@ -10,12 +10,14 @@ parser.add_argument('--read', '-r', dest='pcapFile',
                    help='parse .pcap file from tcpdump')
 parser.add_argument('--capture', '-c', dest='pcapFilter',
                    help='capture packets with given filter')
+parser.add_argument('--interface', '-i', dest='interface',
+                   help='capture on given interface')
 args = parser.parse_args()
 
 if args.pcapFile:
     http_parse.display_pcap_file(args.pcapFile)
 else:
-    pc = pcap.pcap()
+    pc = pcap.pcap(name=args.interface)
     pc.setfilter(args.pcapFilter)
     print 'listening on %s: %s' % (pc.name, pc.filter)
 


### PR DESCRIPTION
Tcpdump offers "-i ethN" command line arg.
This change adds "-i ethN" command line argument to httpdump.

(*) Although same functionality is available via "ifname ethN", alias "on ethN", selector, libpcap is often built without pf (kernel packetfilter api?), and these selectors cannot be used.
